### PR TITLE
Debug/acceptance

### DIFF
--- a/ConfFiles/mc_conf/clas6mc_1p0pianalysis_eC12_1GeV.txt
+++ b/ConfFiles/mc_conf/clas6mc_1p0pianalysis_eC12_1GeV.txt
@@ -1,4 +1,4 @@
-#Analysis Cuts
+B1;95;0c#Analysis Cuts
 DisableSector   2,4
 ApplyFiducial   true
 ApplyAccWeights true
@@ -19,7 +19,7 @@ offset			0
 #Run Configurables
 EBeam			1.161
 TargetPdg		1000060120
-NEvents			100000000
+NEvents			1000000
 FirstEvent		0
 
 #Topology definition

--- a/ConfFiles/mc_conf/clas6mc_1p0pianalysis_eC12_2GeV.txt
+++ b/ConfFiles/mc_conf/clas6mc_1p0pianalysis_eC12_2GeV.txt
@@ -1,4 +1,4 @@
-#Analysis Cuts
+B1;95;0c#Analysis Cuts
 DisableSector   2,3,4
 ApplyFiducial   true
 ApplyAccWeights true
@@ -19,7 +19,7 @@ offset			0
 #Run Configurables
 EBeam			2.261
 TargetPdg		1000060120
-NEvents			5000000
+NEvents			500000
 FirstEvent		0
 
 #Topology definition

--- a/ConfFiles/mc_conf/clas6mc_Inclusive_eC12_1GeV.txt
+++ b/ConfFiles/mc_conf/clas6mc_Inclusive_eC12_1GeV.txt
@@ -19,7 +19,7 @@ offset			0
 #Run Configurables
 EBeam			1.161
 TargetPdg		1000060120
-NEvents			100000000
+NEvents			10000000
 FirstEvent		0
 
 #Topology definition

--- a/src/analysis/AnalysisI.cxx
+++ b/src/analysis/AnalysisI.cxx
@@ -103,23 +103,26 @@ bool AnalysisI::Analyse( Event & event ) {
   // No Cuts are applied on those
   this->CookEvent( event ) ;
 
-  // Smear before appling mom cuts 
+  // (*) Step 4 : Smear before appling mom cuts 
   if( ApplyReso() && !IsData() ) {
     this -> SmearParticles( event ) ; 
   }
 
-  // Step 4 : Apply momentum cut (detector specific)
+  // Step 5 : Apply momentum cut (detector specific)
   if( ApplyMomCut() ) {
     this->ApplyMomentumCut( event ) ;
   }
 
-  // Apply angle cuts, theta for electron protons and pions
+  // Step 6 : Apply angle cuts, theta for electron protons and pions
   // these are applied to both data and MC
   if ( ! this->ApplyFiducialCutExtra( event ) ) {
     return false ;
   }
+
+  // Store analysis record after momentum cuts and general angle cuts:
+  event.StoreAnalysisRecord(kid_acuts);
   
-  // Step 5 : Remove true Bkg events if requested before applying fiducial cuts:
+  // Step 7 : Remove true Bkg events if requested before applying fiducial cuts:
   if (IsTrueSignal() && !IsData() )
     {
       std::map<int, unsigned int> Topology = GetTopology();
@@ -135,9 +138,7 @@ bool AnalysisI::Analyse( Event & event ) {
 	}
     }  
 
-  // Store analysis record after momentum cuts and general angle cuts:
-  event.StoreAnalysisRecord(kid_acuts);
-
+  // (*) Step 8 : apply fiducial if requested
   // The detector has gaps where the particles cannot be detected
   // We need to account for these with fiducial cuts
   // It also takes into account angle cuts for particles

--- a/src/analysis/AnalysisI.cxx
+++ b/src/analysis/AnalysisI.cxx
@@ -34,7 +34,7 @@ bool AnalysisI::Analyse( Event & event ) {
 
   TLorentzVector in_mom = event.GetInLepton4Mom() ;
   TLorentzVector out_mom = event.GetOutLepton4Mom() ;
-
+  
   // Step 1 : Apply generic cuts
   if ( (unsigned int) event.GetTargetPdg() != GetConfiguredTarget() ) {
     std::cout << "Target is " << event.GetTargetPdg() << " instead of " << GetConfiguredTarget() << ". Configuration failed. Exit" << std::endl;
@@ -60,8 +60,8 @@ bool AnalysisI::Analyse( Event & event ) {
   }
 
   if( ApplyThetaSlice() ) {
-    if( out_mom.Theta() * 180./TMath::Pi() < conf::kMinEThetaSlice ) return false ;
-    if( out_mom.Theta() * 180./TMath::Pi() > conf::kMaxEThetaSlice ) return false ;
+    if( out_mom.Theta() * 180./TMath::Pi() < GetEThetaSliceMin() ) return false ;
+    if( out_mom.Theta() * 180./TMath::Pi() > GetEThetaSliceMax() ) return false ;
   }
 
   if( ApplyPhiOpeningAngle() ) {

--- a/src/analysis/AnalysisI.cxx
+++ b/src/analysis/AnalysisI.cxx
@@ -1,7 +1,7 @@
 /**
-* \info These parameters are configurable
-* the default values are set here
-**/
+ * \info These parameters are configurable
+ * the default values are set here
+ **/
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -46,7 +46,7 @@ bool AnalysisI::Analyse( Event & event ) {
   if ( wght < 0 || wght > 10 || wght == 0 ) {
     return false ;
   }
-
+  
   if( kElectronFit && out_mom.Theta() * 180 / TMath::Pi() < GetElectronMinTheta( out_mom ) ) return false ;
 
   // GENIE coordinate system flipped with respect to CLAS
@@ -88,7 +88,7 @@ bool AnalysisI::Analyse( Event & event ) {
       if( W_var > MinW ) return false ;
     }
   }
-
+  
   // Apply Mott Scaling to correct for different coupling
   if ( ApplyMottScaling() ) {
     event.SetMottXSecWeight() ;
@@ -96,12 +96,17 @@ bool AnalysisI::Analyse( Event & event ) {
 
   // Store analysis record before momentum cuts (0) :
   event.StoreAnalysisRecord(kid_bcuts);
-
+  
   // Step 3: Cook event
   // Remove particles not specified in topology maps
   // These are ignored in the analysis
   // No Cuts are applied on those
   this->CookEvent( event ) ;
+
+  // Smear before appling mom cuts 
+  if( ApplyReso() && !IsData() ) {
+    this -> SmearParticles( event ) ; 
+  }
 
   // Step 4 : Apply momentum cut (detector specific)
   if( ApplyMomCut() ) {
@@ -113,30 +118,29 @@ bool AnalysisI::Analyse( Event & event ) {
   if ( ! this->ApplyFiducialCutExtra( event ) ) {
     return false ;
   }
+  
+  // Step 5 : Remove true Bkg events if requested before applying fiducial cuts:
+  if (IsTrueSignal() && !IsData() )
+    {
+      std::map<int, unsigned int> Topology = GetTopology();
+      std::map<int, std::vector<TLorentzVector>> hadrons = event.GetFinalParticles4Mom();
+      for (auto it = Topology.begin(); it != Topology.end(); ++it)
+	{
+	  if (it->first == conf::kPdgElectron)
+	    continue;
+	  if (hadrons[it->first].size() != it->second)
+	    {
+	      return false;
+	    }
+	}
+    }  
 
   // Store analysis record after momentum cuts and general angle cuts:
   event.StoreAnalysisRecord(kid_acuts);
 
-  // Step 5 : Remove true Bkg events if requested before applying fiducial cuts:
-  if (IsTrueSignal() && !IsData() )
-  {
-    std::map<int, unsigned int> Topology = GetTopology();
-    std::map<int, std::vector<TLorentzVector>> hadrons = event.GetFinalParticles4Mom();
-    for (auto it = Topology.begin(); it != Topology.end(); ++it)
-    {
-      if (it->first == conf::kPdgElectron)
-      continue;
-      if (hadrons[it->first].size() != it->second)
-      {
-        return false;
-      }
-    }
-  }
-
-  // Step 5: The detector has gaps where the particles cannot be detected
+  // The detector has gaps where the particles cannot be detected
   // We need to account for these with fiducial cuts
-  // We need it also for data as sometimes we compute the geometrical systematics
-  // by shrinking the phy acceptance
+  // It also takes into account angle cuts for particles
   if ( ! this->ApplyFiducialCut( event, ApplyFiducial() ) ) {
     return false;
   }
@@ -211,408 +215,431 @@ void AnalysisI::PlotBkgInformation( Event event ) {
 
   for ( unsigned obs_id = 0 ; obs_id < tags.size() ; ++obs_id ) {
     if( !kHistograms[tags[obs_id]][kid_totestbkg] || !kHistograms[tags[obs_id]][kid_signal] || !kHistograms[tags[obs_id]][kid_tottruebkg]
-      || !kHistograms[tags[obs_id]][kid_2p0pitruebkg] || !kHistograms[tags[obs_id]][kid_1p1pitruebkg] || !kHistograms[tags[obs_id]][kid_2p1pitruebkg] || !kHistograms[tags[obs_id]][kid_1p2pitruebkg]
-      || !kHistograms[tags[obs_id]][kid_2p0piestbkg] || !kHistograms[tags[obs_id]][kid_1p1piestbkg] || !kHistograms[tags[obs_id]][kid_2p1piestbkg] || !kHistograms[tags[obs_id]][kid_1p2piestbkg] ) return ;
+	|| !kHistograms[tags[obs_id]][kid_2p0pitruebkg] || !kHistograms[tags[obs_id]][kid_1p1pitruebkg] || !kHistograms[tags[obs_id]][kid_2p1pitruebkg] || !kHistograms[tags[obs_id]][kid_1p2pitruebkg]
+	|| !kHistograms[tags[obs_id]][kid_2p0piestbkg] || !kHistograms[tags[obs_id]][kid_1p1piestbkg] || !kHistograms[tags[obs_id]][kid_2p1piestbkg] || !kHistograms[tags[obs_id]][kid_1p2piestbkg] ) return ;
 
-      if( event.IsBkg() == true ) {
-        // This is used to estimate the total background contribution
-        kHistograms[tags[obs_id]][kid_totestbkg]->Fill( event.GetObservable(tags[obs_id]), - event.GetTotalWeight() ) ;
+    if( event.IsBkg() == true ) {
+      // This is used to estimate the total background contribution
+      kHistograms[tags[obs_id]][kid_totestbkg]->Fill( event.GetObservable(tags[obs_id]), - event.GetTotalWeight() ) ;
 
-        // Store contributions from different multiplicities
-        // Check only direct contribution :
-        unsigned int original_mult = min_mult + 1 ;
-        for( unsigned int j = 0 ; j < max_mult - min_mult ; ++j ) {
-          bool is_m_bkg = true ;
-          if( (AnalysisRecord[original_mult+kid_bkgcorr].first).size() != min_mult ) is_m_bkg = false ;
+      // Store contributions from different multiplicities
+      // Check only direct contribution :
+      unsigned int original_mult = min_mult + 1 ;
+      for( unsigned int j = 0 ; j < max_mult - min_mult ; ++j ) {
+	bool is_m_bkg = true ;
+	if( (AnalysisRecord[original_mult+kid_bkgcorr].first).size() != min_mult ) is_m_bkg = false ;
 
-          // Fill for direct contributions only
-          unsigned int id2 = kid_totestbkg + original_mult - min_mult ;
-          if( kHistograms[tags[obs_id]][id2] && is_m_bkg ) {
-            kHistograms[tags[obs_id]][id2]->Fill( event.GetObservable(tags[obs_id]), -event.GetTotalWeight() ) ;
-          }
+	// Fill for direct contributions only
+	unsigned int id2 = kid_totestbkg + original_mult - min_mult ;
+	if( kHistograms[tags[obs_id]][id2] && is_m_bkg ) {
+	  kHistograms[tags[obs_id]][id2]->Fill( event.GetObservable(tags[obs_id]), -event.GetTotalWeight() ) ;
+	}
 
-          // Filling for specific topologies:
-          // First, we need to get the correct mother pdg list.
-          std::vector<int> pdgs ;
-          if( (record_afiducials.first).size() == original_mult ) pdgs = record_afiducials.first ; // It comes directly from background event
-          else if( (AnalysisRecord[original_mult+1+kid_bkgcorr].first).size() == original_mult ) pdgs= AnalysisRecord[original_mult+1+kid_bkgcorr].first ;
-          // It comes from original_mult + 1 event
-          // If none of the two cases above, the bkg event comes directly from a higher multiplicity event ... discard.
-          // Only considering direct contributions or corrections
+	// Filling for specific topologies:
+	// First, we need to get the correct mother pdg list.
+	std::vector<int> pdgs ;
+	if( (record_afiducials.first).size() == original_mult ) pdgs = record_afiducials.first ; // It comes directly from background event
+	else if( (AnalysisRecord[original_mult+1+kid_bkgcorr].first).size() == original_mult ) pdgs= AnalysisRecord[original_mult+1+kid_bkgcorr].first ;
+	// It comes from original_mult + 1 event
+	// If none of the two cases above, the bkg event comes directly from a higher multiplicity event ... discard.
+	// Only considering direct contributions or corrections
 
-          // Count number of protons and pions
-          unsigned int nprotons = 0 ;
-          unsigned int npions = 0 ;
-          for ( unsigned int k = 0 ; k < pdgs.size() ; ++k ) {
-            int particle_pdg = pdgs[k];
-            if( particle_pdg == conf::kPdgProton ) ++nprotons ;
-            else if ( particle_pdg == conf::kPdgPiP || particle_pdg == conf::kPdgPiM || particle_pdg == conf::kPdgPi0 || particle_pdg == conf::kPdgPhoton ) ++npions ;
-          }
+	// Count number of protons and pions
+	unsigned int nprotons = 0 ;
+	unsigned int npions = 0 ;
+	for ( unsigned int k = 0 ; k < pdgs.size() ; ++k ) {
+	  int particle_pdg = pdgs[k];
+	  if( particle_pdg == conf::kPdgProton ) ++nprotons ;
+	  else if ( particle_pdg == conf::kPdgPiP || particle_pdg == conf::kPdgPiM || particle_pdg == conf::kPdgPi0 || particle_pdg == conf::kPdgPhoton ) ++npions ;
+	}
 
-          // Add breakdown in topologies
-          if( original_mult == 2 ) {
-            // Store according to initial topology
-            if( nprotons == 2 && npions == 0 ) kHistograms[tags[obs_id]][kid_2p0piestbkg]->Fill( event.GetObservable(tags[obs_id]), -event.GetTotalWeight() ) ;
-            if( nprotons == 1 && npions == 1 ) kHistograms[tags[obs_id]][kid_1p1piestbkg]->Fill( event.GetObservable(tags[obs_id]), -event.GetTotalWeight() ) ;
-          } else if (original_mult == 3 ) {
-            // Store according to initial topology
-            if( nprotons == 2 && npions == 1 ) kHistograms[tags[obs_id]][kid_2p1piestbkg]->Fill( event.GetObservable(tags[obs_id]), -event.GetTotalWeight() ) ;
-            if( nprotons == 1 && npions == 2 ) kHistograms[tags[obs_id]][kid_1p2piestbkg]->Fill( event.GetObservable(tags[obs_id]), -event.GetTotalWeight() ) ;
-          }
+	// Add breakdown in topologies
+	if( original_mult == 2 ) {
+	  // Store according to initial topology
+	  if( nprotons == 2 && npions == 0 ) kHistograms[tags[obs_id]][kid_2p0piestbkg]->Fill( event.GetObservable(tags[obs_id]), -event.GetTotalWeight() ) ;
+	  if( nprotons == 1 && npions == 1 ) kHistograms[tags[obs_id]][kid_1p1piestbkg]->Fill( event.GetObservable(tags[obs_id]), -event.GetTotalWeight() ) ;
+	} else if (original_mult == 3 ) {
+	  // Store according to initial topology
+	  if( nprotons == 2 && npions == 1 ) kHistograms[tags[obs_id]][kid_2p1piestbkg]->Fill( event.GetObservable(tags[obs_id]), -event.GetTotalWeight() ) ;
+	  if( nprotons == 1 && npions == 2 ) kHistograms[tags[obs_id]][kid_1p2piestbkg]->Fill( event.GetObservable(tags[obs_id]), -event.GetTotalWeight() ) ;
+	}
 
-          ++original_mult;
-        }
+	++original_mult;
+      }
+    } else {
+      // These are singal events. They are classified as either true signal or bkg events that contribute to signal after fiducial
+      if( (record_afiducials.first).size() == (record_amomcuts.first).size() && (record_acccorr.first).size() == 0 ) {
+	kHistograms[tags[obs_id]][kid_signal]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
       } else {
-        // These are singal events. They are classified as either true signal or bkg events that contribute to signal after fiducial
-        if( (record_afiducials.first).size() == (record_amomcuts.first).size() && (record_acccorr.first).size() == 0 ) {
-          kHistograms[tags[obs_id]][kid_signal]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
-        } else {
-          kHistograms[tags[obs_id]][kid_tottruebkg]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
+	kHistograms[tags[obs_id]][kid_tottruebkg]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
 
-          // Fill each multiplicity contribution
-          unsigned int id = (record_amomcuts.first).size() - min_mult ;
-          if( kHistograms[tags[obs_id]][kid_tottruebkg+id] ) kHistograms[tags[obs_id]][kid_tottruebkg+id]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
+	// Fill each multiplicity contribution
+	unsigned int id = (record_amomcuts.first).size() - min_mult ;
+	if( kHistograms[tags[obs_id]][kid_tottruebkg+id] ) kHistograms[tags[obs_id]][kid_tottruebkg+id]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
 
-          // Count number of protons and pions
-          unsigned int nprotons = 0 ;
-          unsigned int npions = 0 ;
-          for ( unsigned int k = 0 ; k < (record_amomcuts.first).size() ; ++k ) {
-            int particle_pdg = (record_amomcuts.first)[k];
-            if( particle_pdg == conf::kPdgProton ) ++nprotons ;
-            else if ( particle_pdg == conf::kPdgPiP || particle_pdg == conf::kPdgPiM || particle_pdg == conf::kPdgPi0 || particle_pdg == conf::kPdgPhoton ) ++npions ;
-          }
+	// Count number of protons and pions
+	unsigned int nprotons = 0 ;
+	unsigned int npions = 0 ;
+	for ( unsigned int k = 0 ; k < (record_amomcuts.first).size() ; ++k ) {
+	  int particle_pdg = (record_amomcuts.first)[k];
+	  if( particle_pdg == conf::kPdgProton ) ++nprotons ;
+	  else if ( particle_pdg == conf::kPdgPiP || particle_pdg == conf::kPdgPiM || particle_pdg == conf::kPdgPi0 || particle_pdg == conf::kPdgPhoton ) ++npions ;
+	}
 
-          // Add breakdown in topologies
-          if( (record_amomcuts.first).size() == 2 ) {
-            // Store according to initial topology
-            if( nprotons == 2 && npions == 0 ) kHistograms[tags[obs_id]][kid_2p0pitruebkg]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
-            if( nprotons == 1 && npions == 1 ) kHistograms[tags[obs_id]][kid_1p1pitruebkg]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
-          } else if ( (record_amomcuts.first).size() == 3 ) {
-            // Store according to initial topology
-            if( nprotons == 2 && npions == 1 ) kHistograms[tags[obs_id]][kid_2p1pitruebkg]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
-            if( nprotons == 1 && npions == 2 ) kHistograms[tags[obs_id]][kid_1p2pitruebkg]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
-          }
-        }
+	// Add breakdown in topologies
+	if( (record_amomcuts.first).size() == 2 ) {
+	  // Store according to initial topology
+	  if( nprotons == 2 && npions == 0 ) kHistograms[tags[obs_id]][kid_2p0pitruebkg]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
+	  if( nprotons == 1 && npions == 1 ) kHistograms[tags[obs_id]][kid_1p1pitruebkg]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
+	} else if ( (record_amomcuts.first).size() == 3 ) {
+	  // Store according to initial topology
+	  if( nprotons == 2 && npions == 1 ) kHistograms[tags[obs_id]][kid_2p1pitruebkg]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
+	  if( nprotons == 1 && npions == 2 ) kHistograms[tags[obs_id]][kid_1p2pitruebkg]->Fill( event.GetObservable(tags[obs_id]), event.GetTotalWeight() ) ;
+	}
       }
     }
   }
+}
 
-  double AnalysisI::GetElectronMinTheta( TLorentzVector emom ) {
-    if( !kElectronFit ) return -999. ;
-    return kElectronFit ->Eval(emom.P()) ;
+double AnalysisI::GetElectronMinTheta( TLorentzVector emom ) {
+  if( !kElectronFit ) return -999. ;
+  return kElectronFit ->Eval(emom.P()) ;
+}
+
+void AnalysisI::Initialize(void) {
+  double Ebeam = GetConfiguredEBeam() ;
+
+  kElectronFit = new TF1( "myElectronFit", "[0]+[1]/x",0.,0.5);
+  if( !kElectronFit ) kIsConfigured = false ;
+  else {
+    if( Ebeam == 1.161 ) { kElectronFit -> SetParameters(17,7) ; }
+    else if( Ebeam == 2.261 ) { kElectronFit -> SetParameters(16,10.5) ; }
+    else if( Ebeam == 4.461 ) { kElectronFit -> SetParameters(13.5,15) ; }
+    else { kElectronFit -> SetParameters(13.5,15) ; }
+    kIsConfigured = InitializeFiducial() ;
   }
 
-  void AnalysisI::Initialize(void) {
-    double Ebeam = GetConfiguredEBeam() ;
+}
 
-    kElectronFit = new TF1( "myElectronFit", "[0]+[1]/x",0.,0.5);
-    if( !kElectronFit ) kIsConfigured = false ;
-    else {
-      if( Ebeam == 1.161 ) { kElectronFit -> SetParameters(17,7) ; }
-      else if( Ebeam == 2.261 ) { kElectronFit -> SetParameters(16,10.5) ; }
-      else if( Ebeam == 4.461 ) { kElectronFit -> SetParameters(13.5,15) ; }
-      else { kElectronFit -> SetParameters(13.5,15) ; }
-      kIsConfigured = InitializeFiducial() ;
-    }
+bool AnalysisI::ApplyFiducialCut( Event & event, bool apply_fiducial ) {
+  // First, we apply it to the electron
+  // Apply fiducial cut to electron
+  Fiducial * fiducial = GetFiducialCut() ;
+  if( ! fiducial ) return true ;
 
-  }
+  TLorentzVector out_mom = event.GetOutLepton4Mom() ;
+  if (! fiducial -> FiducialCut(conf::kPdgElectron, GetConfiguredEBeam(), out_mom.Vect(), IsData(), apply_fiducial ) ) return false ;
 
-  bool AnalysisI::ApplyFiducialCut( Event & event, bool apply_fiducial ) {
-    // First, we apply it to the electron
-    // Apply fiducial cut to electron
-    Fiducial * fiducial = GetFiducialCut() ;
-    if( ! fiducial ) return true ;
+  // Apply Fiducial cut for hadrons and photons
+  std::map<int,std::vector<TLorentzVector>> part_map = event.GetFinalParticles4Mom() ;
+  std::map<int,std::vector<TLorentzVector>> part_map_uncorr = event.GetFinalParticlesUnCorr4Mom() ;
+  std::map<int,std::vector<TLorentzVector>> contained_part_map, contained_part_map_uncorr ;
+  for( auto it = part_map.begin() ; it != part_map.end() ; ++it ) {
+    std::vector<TLorentzVector> visible_part ;
+    std::vector<TLorentzVector> visible_part_uncorr ;
+    for( unsigned int i = 0 ; i < part_map[it->first].size() ; ++i ) {
+      if( ! fiducial -> FiducialCut(it->first, GetConfiguredEBeam(), part_map[it->first][i].Vect(), IsData(), apply_fiducial ) ) continue ;
 
-    TLorentzVector out_mom = event.GetOutLepton4Mom() ;
-    if (! fiducial -> FiducialCut(conf::kPdgElectron, GetConfiguredEBeam(), out_mom.Vect(), IsData(), apply_fiducial ) ) return false ;
-
-    // Apply Fiducial cut for hadrons and photons
-    std::map<int,std::vector<TLorentzVector>> part_map = event.GetFinalParticles4Mom() ;
-    std::map<int,std::vector<TLorentzVector>> part_map_uncorr = event.GetFinalParticlesUnCorr4Mom() ;
-    std::map<int,std::vector<TLorentzVector>> contained_part_map, contained_part_map_uncorr ;
-    for( auto it = part_map.begin() ; it != part_map.end() ; ++it ) {
-      std::vector<TLorentzVector> visible_part ;
-      std::vector<TLorentzVector> visible_part_uncorr ;
-      for( unsigned int i = 0 ; i < part_map[it->first].size() ; ++i ) {
-        if( ! fiducial -> FiducialCut(it->first, GetConfiguredEBeam(), part_map[it->first][i].Vect(), IsData(), apply_fiducial ) ) continue ;
-
-        // Consider case in which we shift the fiducial
-        // Instead of changing the fiducial limits, we change the phi of each particle
-        // To shrink the fiducial we must move the particle closer to the edge
-        // Instead of chekcing which edge is closer, we compute both shifts... and check if it is still there
-        TLorentzVector out_mom_part_shift = part_map[it->first][i] ;
-        if( fFidAngleShift != 0 ) {
-          out_mom_part_shift.SetPhi( part_map[it->first][i].Phi() + fFidAngleShift * TMath::Pi() / 180. ) ;
-          if( ! fiducial -> FiducialCut(it->first, GetConfiguredEBeam(), out_mom_part_shift.Vect(), IsData(), apply_fiducial ) ) continue ;
-          out_mom_part_shift.SetPhi( part_map[it->first][i].Phi() - fFidAngleShift * TMath::Pi() / 180. ) ;
-          if( ! fiducial -> FiducialCut(it->first, GetConfiguredEBeam(), out_mom_part_shift.Vect(), IsData(), apply_fiducial ) ) continue ;
-        }
-
-        visible_part.push_back( part_map[it->first][i] ) ;
-        visible_part_uncorr.push_back( part_map_uncorr[it->first][i] ) ;
+      // Consider case in which we shift the fiducial
+      // Instead of changing the fiducial limits, we change the phi of each particle
+      // To shrink the fiducial we must move the particle closer to the edge
+      // Instead of chekcing which edge is closer, we compute both shifts... and check if it is still there
+      TLorentzVector out_mom_part_shift = part_map[it->first][i] ;
+      if( fFidAngleShift != 0 ) {
+	out_mom_part_shift.SetPhi( part_map[it->first][i].Phi() + fFidAngleShift * TMath::Pi() / 180. ) ;
+	if( ! fiducial -> FiducialCut(it->first, GetConfiguredEBeam(), out_mom_part_shift.Vect(), IsData(), apply_fiducial ) ) continue ;
+	out_mom_part_shift.SetPhi( part_map[it->first][i].Phi() - fFidAngleShift * TMath::Pi() / 180. ) ;
+	if( ! fiducial -> FiducialCut(it->first, GetConfiguredEBeam(), out_mom_part_shift.Vect(), IsData(), apply_fiducial ) ) continue ;
       }
-      if( visible_part.size() == 0 ) continue ;
-      contained_part_map[it->first] = visible_part ;
-      contained_part_map_uncorr[it->first] = visible_part_uncorr ;
+
+      visible_part.push_back( part_map[it->first][i] ) ;
+      visible_part_uncorr.push_back( part_map_uncorr[it->first][i] ) ;
     }
-
-    // Store changes in event after fiducial cut
-    event.SetFinalParticlesKinematics( contained_part_map ) ;
-    event.SetFinalParticlesUnCorrKinematics( contained_part_map_uncorr ) ;
-
-    return true ;
+    if( visible_part.size() == 0 ) continue ;
+    contained_part_map[it->first] = visible_part ;
+    contained_part_map_uncorr[it->first] = visible_part_uncorr ;
   }
 
-  bool AnalysisI::ApplyFiducialCutExtra( Event & event ) {
-    // First, we apply it to the electron
-    // Apply fiducial cut to electron
-    Fiducial * fiducial = GetFiducialCut() ;
-    if( ! fiducial ) return true ;
+  // Store changes in event after fiducial cut
+  event.SetFinalParticlesKinematics( contained_part_map ) ;
+  event.SetFinalParticlesUnCorrKinematics( contained_part_map_uncorr ) ;
 
-    // apply theta cuts
-    TLorentzVector out_mom = event.GetOutLepton4Mom() ;
-    if (! fiducial -> FiducialCutExtra(conf::kPdgElectron, GetConfiguredEBeam(), out_mom.Vect(), IsData() ) ) return false ;
+  return true ;
+}
 
-    // Apply Fiducial cut for hadrons and photons
-    std::map<int,std::vector<TLorentzVector>> part_map = event.GetFinalParticles4Mom() ;
-    std::map<int,std::vector<TLorentzVector>> part_map_uncorr = event.GetFinalParticlesUnCorr4Mom() ;
-    std::map<int,std::vector<TLorentzVector>> contained_part_map, contained_part_map_uncorr ;
-    for( auto it = part_map.begin() ; it != part_map.end() ; ++it ) {
-      std::vector<TLorentzVector> visible_part ;
-      std::vector<TLorentzVector> visible_part_uncorr ;
-      for( unsigned int i = 0 ; i < part_map[it->first].size() ; ++i ) {
-        if( ! fiducial -> FiducialCutExtra(it->first, GetConfiguredEBeam(), part_map[it->first][i].Vect(), IsData() ) ) continue ;
-        visible_part.push_back( part_map[it->first][i] ) ;
-        visible_part_uncorr.push_back( part_map_uncorr[it->first][i] ) ;
-      }
-      if( visible_part.size() == 0 ) continue ;
-      contained_part_map[it->first] = visible_part ;
-      contained_part_map_uncorr[it->first] = visible_part_uncorr ;
+bool AnalysisI::ApplyFiducialCutExtra( Event & event ) {
+  // First, we apply it to the electron
+  // Apply fiducial cut to electron
+  Fiducial * fiducial = GetFiducialCut() ;
+  if( ! fiducial ) return true ;
+
+  // apply theta cuts
+  TLorentzVector out_mom = event.GetOutLepton4Mom() ;
+  if (! fiducial -> FiducialCutExtra(conf::kPdgElectron, GetConfiguredEBeam(), out_mom.Vect(), IsData() ) ) return false ;
+
+  // Apply Fiducial cut for hadrons and photons
+  std::map<int,std::vector<TLorentzVector>> part_map = event.GetFinalParticles4Mom() ;
+  std::map<int,std::vector<TLorentzVector>> part_map_uncorr = event.GetFinalParticlesUnCorr4Mom() ;
+  std::map<int,std::vector<TLorentzVector>> contained_part_map, contained_part_map_uncorr ;
+  for( auto it = part_map.begin() ; it != part_map.end() ; ++it ) {
+    std::vector<TLorentzVector> visible_part ;
+    std::vector<TLorentzVector> visible_part_uncorr ;
+    for( unsigned int i = 0 ; i < part_map[it->first].size() ; ++i ) {
+      if( ! fiducial -> FiducialCutExtra(it->first, GetConfiguredEBeam(), part_map[it->first][i].Vect(), IsData() ) ) continue ;
+      visible_part.push_back( part_map[it->first][i] ) ;
+      visible_part_uncorr.push_back( part_map_uncorr[it->first][i] ) ;
     }
-
-    // Store changes in event after fiducial cut
-    event.SetFinalParticlesKinematics( contained_part_map ) ;
-    event.SetFinalParticlesUnCorrKinematics( contained_part_map_uncorr ) ;
-
-    return true ;
+    if( visible_part.size() == 0 ) continue ;
+    contained_part_map[it->first] = visible_part ;
+    contained_part_map_uncorr[it->first] = visible_part_uncorr ;
   }
 
+  // Store changes in event after fiducial cut
+  event.SetFinalParticlesKinematics( contained_part_map ) ;
+  event.SetFinalParticlesUnCorrKinematics( contained_part_map_uncorr ) ;
 
-  bool AnalysisI::StoreTree(Event event)
-  {
-    static bool isFirstCall = true;
-    unsigned int InitialNEvents = GetNEventsToRun();
-    double ConversionFactor = conf::kConversionFactorCm2ToMicroBarn * TMath::Power(10., -38.);
-    int ID = event.GetEventID();
-    double BeamE = event.GetInLepton4Mom().E();
-    int TargetPdg = event.GetTargetPdg();
-    int InLeptonPdg = event.GetInLeptPdg();
-    int OutLeptonPdg = event.GetOutLeptPdg();
-    double TotWeight = event.GetTotalWeight();
-    double EventWght = event.GetEventWeight();
+  return true ;
+}
 
-    unsigned int RecoNProtons = event.GetRecoNProtons();
-    unsigned int RecoNNeutrons = event.GetRecoNNeutrons();
-    unsigned int RecoNPiP = event.GetRecoNPiP();
-    unsigned int RecoNPiM = event.GetRecoNPiM();
-    unsigned int RecoNPi0 = event.GetRecoNPi0();
-    unsigned int RecoNKP = event.GetRecoNKP();
-    unsigned int RecoNKM = event.GetRecoNKM();
-    unsigned int RecoNK0 = event.GetRecoNK0();
-    unsigned int RecoNEM = event.GetRecoNEM();
+void AnalysisI::SmearParticles(Event &event)
+{
+  double EBeam = GetConfiguredEBeam();
+  TLorentzVector out_mom = event.GetOutLepton4Mom();
 
-    // Angle rotated if is MC, otherwise not rotated.
-    TLorentzVector out_mom = event.GetOutLepton4Mom();
-    double Efl = out_mom.E();
-    double pfl = out_mom.P();
-    double pflx = out_mom.Px();
-    double pfly = out_mom.Py();
-    double pflz = out_mom.Pz();
-    double pfl_theta = out_mom.Theta() * TMath::RadToDeg();
-    unsigned int ElectronSector = utils::GetSector(out_mom.Phi());
-    double pfl_phi = out_mom.Phi() * TMath::RadToDeg();
-    double pfl_T = utils::GetPT(out_mom.Vect()).Mag();
+  utils::ApplyResolution(conf::kPdgElectron, out_mom, EBeam);
+  event.SetOutLeptonKinematics(out_mom);
 
-    double RecoQELEnu = utils::GetQELRecoEnu(out_mom, TargetPdg);
-    double RecoEnergyTransfer = utils::GetEnergyTransfer(out_mom, BeamE);
-    double Recoq3 = utils::GetRecoq3(out_mom, BeamE).Mag();
-    double RecoQ2 = utils::GetRecoQ2(out_mom, BeamE);
-    double RecoXBJK = utils::GetRecoXBJK(out_mom, BeamE);
-    double RecoW = utils::GetRecoW(out_mom, BeamE);
+  // Apply for other particles
+  std::map<int, std::vector<TLorentzVector>> part_map = event.GetFinalParticles4Mom();
+  for (std::map<int, std::vector<TLorentzVector>>::iterator it = part_map.begin(); it != part_map.end(); ++it)
+    {
+      std::vector<TLorentzVector> vtemp;
+      for (unsigned int i = 0; i < (it->second).size(); ++i)
+	{
+	  TLorentzVector temp = (it->second)[i];
+	  utils::ApplyResolution(it->first, temp, EBeam);
+	  vtemp.push_back(temp);
+	}
+      part_map[it->first] = vtemp;
+    }
+  event.SetFinalParticlesKinematics(part_map);
+}
 
-    double MottXSecScale = event.GetMottXSecWeight();
+bool AnalysisI::StoreTree(Event event)
+{
+  static bool isFirstCall = true;
+  unsigned int InitialNEvents = GetNEventsToRun();
+  double ConversionFactor = conf::kConversionFactorCm2ToMicroBarn * TMath::Power(10., -38.);
+  int ID = event.GetEventID();
+  double BeamE = event.GetInLepton4Mom().E();
+  int TargetPdg = event.GetTargetPdg();
+  int InLeptonPdg = event.GetInLeptPdg();
+  int OutLeptonPdg = event.GetOutLeptPdg();
+  double TotWeight = event.GetTotalWeight();
+  double EventWght = event.GetEventWeight();
 
-    std::map<int, unsigned int> topology = GetTopology();
-    static bool topology_has_protons = false;
-    if (topology.count(conf::kPdgProton) != 0)
+  unsigned int RecoNProtons = event.GetRecoNProtons();
+  unsigned int RecoNNeutrons = event.GetRecoNNeutrons();
+  unsigned int RecoNPiP = event.GetRecoNPiP();
+  unsigned int RecoNPiM = event.GetRecoNPiM();
+  unsigned int RecoNPi0 = event.GetRecoNPi0();
+  unsigned int RecoNKP = event.GetRecoNKP();
+  unsigned int RecoNKM = event.GetRecoNKM();
+  unsigned int RecoNK0 = event.GetRecoNK0();
+  unsigned int RecoNEM = event.GetRecoNEM();
+
+  // Angle rotated if is MC, otherwise not rotated.
+  TLorentzVector out_mom = event.GetOutLepton4Mom();
+  double Efl = out_mom.E();
+  double pfl = out_mom.P();
+  double pflx = out_mom.Px();
+  double pfly = out_mom.Py();
+  double pflz = out_mom.Pz();
+  double pfl_theta = out_mom.Theta() * TMath::RadToDeg();
+  unsigned int ElectronSector = utils::GetSector(out_mom.Phi());
+  double pfl_phi = out_mom.Phi() * TMath::RadToDeg();
+  double pfl_T = utils::GetPT(out_mom.Vect()).Mag();
+
+  double RecoQELEnu = utils::GetQELRecoEnu(out_mom, TargetPdg);
+  double RecoEnergyTransfer = utils::GetEnergyTransfer(out_mom, BeamE);
+  double Recoq3 = utils::GetRecoq3(out_mom, BeamE).Mag();
+  double RecoQ2 = utils::GetRecoQ2(out_mom, BeamE);
+  double RecoXBJK = utils::GetRecoXBJK(out_mom, BeamE);
+  double RecoW = utils::GetRecoW(out_mom, BeamE);
+
+  double MottXSecScale = event.GetMottXSecWeight();
+
+  std::map<int, unsigned int> topology = GetTopology();
+  static bool topology_has_protons = false;
+  if (topology.count(conf::kPdgProton) != 0)
     {
       if (topology[conf::kPdgProton] != 0)
-      topology_has_protons = true;
+	topology_has_protons = true;
     }
-    static bool topology_has_pip = false;
-    if (topology.count(conf::kPdgPiP) != 0)
+  static bool topology_has_pip = false;
+  if (topology.count(conf::kPdgPiP) != 0)
     {
       if (topology[conf::kPdgPiP] != 0)
-      topology_has_pip = true;
+	topology_has_pip = true;
     }
 
-    static bool topology_has_pim = false;
-    if (topology.count(conf::kPdgPiM) != 0)
+  static bool topology_has_pim = false;
+  if (topology.count(conf::kPdgPiM) != 0)
     {
       if (topology[conf::kPdgPiM] != 0)
-      topology_has_pim = true;
+	topology_has_pim = true;
     }
 
-    unsigned int TopMult = GetNTopologyParticles();
+  unsigned int TopMult = GetNTopologyParticles();
 
-    // flip hadrons phi
-    std::map<int, std::vector<TLorentzVector>> hadron_map = event.GetFinalParticles4Mom();
-    TLorentzVector p_max(0, 0, 0, 0);
-    if (topology_has_protons)
+  // flip hadrons phi
+  std::map<int, std::vector<TLorentzVector>> hadron_map = event.GetFinalParticles4Mom();
+  TLorentzVector p_max(0, 0, 0, 0);
+  if (topology_has_protons)
     {
       double max_mom = 0;
       for (unsigned int i = 0; i < hadron_map[conf::kPdgProton].size(); ++i)
-      {
-        if (hadron_map[conf::kPdgProton][i].P() > max_mom)
-        {
-          max_mom = hadron_map[conf::kPdgProton][i].P();
-          p_max = hadron_map[conf::kPdgProton][i];
-        }
-      }
+	{
+	  if (hadron_map[conf::kPdgProton][i].P() > max_mom)
+	    {
+	      max_mom = hadron_map[conf::kPdgProton][i].P();
+	      p_max = hadron_map[conf::kPdgProton][i];
+	    }
+	}
     }
 
-    double HadronsAngle = 0;
-    std::vector<TLorentzVector> particles;
-    for (auto it = hadron_map.begin(); it != hadron_map.end(); ++it)
+  double HadronsAngle = 0;
+  std::vector<TLorentzVector> particles;
+  for (auto it = hadron_map.begin(); it != hadron_map.end(); ++it)
     {
       if ((it->second).size() != 1)
-      continue;
+	continue;
       for (unsigned int i = 0; i < (it->second).size(); ++i)
-      {
-        particles.push_back((it->second)[i]);
-      }
+	{
+	  particles.push_back((it->second)[i]);
+	}
     }
-    if (particles.size() == 2)
+  if (particles.size() == 2)
     {
       HadronsAngle = utils::Angle(particles[0].Vect(), particles[1].Vect()) * TMath::RadToDeg();
     }
 
-    double proton_E = p_max.E();
-    double proton_mom = p_max.P();
-    double proton_momx = p_max.Px();
-    double proton_momy = p_max.Py();
-    double proton_momz = p_max.Pz();
-    double proton_theta = p_max.Theta() * TMath::RadToDeg();
-    double proton_phi = p_max.Phi() * TMath::RadToDeg();
-    double ECal = utils::GetECal(out_mom.E(), event.GetFinalParticles4Mom(), TargetPdg);
-    double DiffECal = utils::GetECal(out_mom.E(), event.GetFinalParticles4Mom(), TargetPdg) - BeamE;
-    double AlphaT = utils::DeltaAlphaT(out_mom.Vect(), p_max.Vect());
-    double DeltaPT = utils::DeltaPT(out_mom.Vect(), p_max.Vect()).Mag();
-    double DeltaPhiT = utils::DeltaPhiT(out_mom.Vect(), p_max.Vect());
-    double HadAlphaT = utils::DeltaAlphaT(out_mom, hadron_map);
-    double HadDeltaPT = utils::DeltaPT(out_mom, hadron_map).Mag();
-    double HadDeltaPTx = utils::DeltaPTx(out_mom, hadron_map);
-    double HadDeltaPTy = utils::DeltaPTy(out_mom, hadron_map);
-    double HadDeltaPhiT = utils::DeltaPhiT(out_mom, hadron_map);
-    double InferedNucleonMom = utils::InferedNucleonMom(BeamE, out_mom, hadron_map, TargetPdg);
+  double proton_E = p_max.E();
+  double proton_mom = p_max.P();
+  double proton_momx = p_max.Px();
+  double proton_momy = p_max.Py();
+  double proton_momz = p_max.Pz();
+  double proton_theta = p_max.Theta() * TMath::RadToDeg();
+  double proton_phi = p_max.Phi() * TMath::RadToDeg();
+  double ECal = utils::GetECal(out_mom.E(), event.GetFinalParticles4Mom(), TargetPdg);
+  double DiffECal = utils::GetECal(out_mom.E(), event.GetFinalParticles4Mom(), TargetPdg) - BeamE;
+  double AlphaT = utils::DeltaAlphaT(out_mom.Vect(), p_max.Vect());
+  double DeltaPT = utils::DeltaPT(out_mom.Vect(), p_max.Vect()).Mag();
+  double DeltaPhiT = utils::DeltaPhiT(out_mom.Vect(), p_max.Vect());
+  double HadAlphaT = utils::DeltaAlphaT(out_mom, hadron_map);
+  double HadDeltaPT = utils::DeltaPT(out_mom, hadron_map).Mag();
+  double HadDeltaPTx = utils::DeltaPTx(out_mom, hadron_map);
+  double HadDeltaPTy = utils::DeltaPTy(out_mom, hadron_map);
+  double HadDeltaPhiT = utils::DeltaPhiT(out_mom, hadron_map);
+  double InferedNucleonMom = utils::InferedNucleonMom(BeamE, out_mom, hadron_map, TargetPdg);
 
-    TLorentzVector pip_max(0, 0, 0, 0);
-    if (topology_has_pip)
+  TLorentzVector pip_max(0, 0, 0, 0);
+  if (topology_has_pip)
     {
       double max_mom = 0;
       for (unsigned int i = 0; i < hadron_map[conf::kPdgPiP].size(); ++i)
-      {
-        if (hadron_map[conf::kPdgPiP][i].P() > max_mom)
-        {
-          max_mom = hadron_map[conf::kPdgPiP][i].P();
-          pip_max = hadron_map[conf::kPdgPiP][i];
-        }
-      }
+	{
+	  if (hadron_map[conf::kPdgPiP][i].P() > max_mom)
+	    {
+	      max_mom = hadron_map[conf::kPdgPiP][i].P();
+	      pip_max = hadron_map[conf::kPdgPiP][i];
+	    }
+	}
     }
 
-    double pip_E = pip_max.E();
-    double pip_mom = pip_max.P();
-    double pip_momx = pip_max.Px();
-    double pip_momy = pip_max.Py();
-    double pip_momz = pip_max.Pz();
-    double pip_theta = pip_max.Theta() * TMath::RadToDeg();
-    double pip_phi = pip_max.Phi() * TMath::RadToDeg();
+  double pip_E = pip_max.E();
+  double pip_mom = pip_max.P();
+  double pip_momx = pip_max.Px();
+  double pip_momy = pip_max.Py();
+  double pip_momz = pip_max.Pz();
+  double pip_theta = pip_max.Theta() * TMath::RadToDeg();
+  double pip_phi = pip_max.Phi() * TMath::RadToDeg();
 
-    TLorentzVector pim_max(0, 0, 0, 0);
-    if (topology_has_pim)
+  TLorentzVector pim_max(0, 0, 0, 0);
+  if (topology_has_pim)
     {
       double max_mom = 0;
       for (unsigned int i = 0; i < hadron_map[conf::kPdgPiM].size(); ++i)
-      {
-        if (hadron_map[conf::kPdgPiM][i].P() > max_mom)
-        {
-          max_mom = hadron_map[conf::kPdgPiM][i].P();
-          pim_max = hadron_map[conf::kPdgPiM][i];
-        }
-      }
+	{
+	  if (hadron_map[conf::kPdgPiM][i].P() > max_mom)
+	    {
+	      max_mom = hadron_map[conf::kPdgPiM][i].P();
+	      pim_max = hadron_map[conf::kPdgPiM][i];
+	    }
+	}
     }
 
-    // Adler angles
-    double AdlerAngleThetaP = utils::GetAdlerAngleTheta(BeamE, out_mom, hadron_map, conf::kPdgProton) * TMath::RadToDeg();
-    double AdlerAnglePhiP = utils::GetAdlerAnglePhi(BeamE, out_mom, hadron_map, conf::kPdgProton) * TMath::RadToDeg();
-    double AdlerAngleThetaPi = utils::GetAdlerAngleTheta(BeamE, out_mom, hadron_map, abs(conf::kPdgPiM)) * TMath::RadToDeg();
-    double AdlerAnglePhiPi = utils::GetAdlerAnglePhi(BeamE, out_mom, hadron_map, abs(conf::kPdgPiM)) * TMath::RadToDeg();
+  // Adler angles
+  double AdlerAngleThetaP = utils::GetAdlerAngleTheta(BeamE, out_mom, hadron_map, conf::kPdgProton) * TMath::RadToDeg();
+  double AdlerAnglePhiP = utils::GetAdlerAnglePhi(BeamE, out_mom, hadron_map, conf::kPdgProton) * TMath::RadToDeg();
+  double AdlerAngleThetaPi = utils::GetAdlerAngleTheta(BeamE, out_mom, hadron_map, abs(conf::kPdgPiM)) * TMath::RadToDeg();
+  double AdlerAnglePhiPi = utils::GetAdlerAnglePhi(BeamE, out_mom, hadron_map, abs(conf::kPdgPiM)) * TMath::RadToDeg();
 
-    // Angle between q and had system
-    double Angleqvshad = utils::Angle(utils::GetRecoq3(out_mom, BeamE), utils::TotHadron(hadron_map).Vect()) * TMath::RadToDeg();
+  // Angle between q and had system
+  double Angleqvshad = utils::Angle(utils::GetRecoq3(out_mom, BeamE), utils::TotHadron(hadron_map).Vect()) * TMath::RadToDeg();
 
-    double HadSystemMass = utils::HadSystemMass(hadron_map);
-    double pim_E = pim_max.E();
-    double pim_mom = pim_max.P();
-    double pim_momx = pim_max.Px();
-    double pim_momy = pim_max.Py();
-    double pim_momz = pim_max.Pz();
-    double pim_theta = pim_max.Theta() * TMath::RadToDeg();
-    double pim_phi = pim_max.Phi() * TMath::RadToDeg();
+  double HadSystemMass = utils::HadSystemMass(hadron_map);
+  double pim_E = pim_max.E();
+  double pim_mom = pim_max.P();
+  double pim_momx = pim_max.Px();
+  double pim_momy = pim_max.Py();
+  double pim_momz = pim_max.Pz();
+  double pim_theta = pim_max.Theta() * TMath::RadToDeg();
+  double pim_phi = pim_max.Phi() * TMath::RadToDeg();
 
-    double MissingEnergy = utils::Missing4Momenta(BeamE, out_mom, hadron_map, TargetPdg).E();
-    double MissingMomentum = utils::Missing4Momenta(BeamE, out_mom, hadron_map, TargetPdg).P();
-    double MissingAngle = utils::Missing4Momenta(BeamE, out_mom, hadron_map, TargetPdg).Theta() * TMath::RadToDeg();
-    double MissingTransMomentum = utils::GetPT(utils::Missing4Momenta(BeamE, out_mom, hadron_map, TargetPdg).Vect()).Mag();
+  double MissingEnergy = utils::Missing4Momenta(BeamE, out_mom, hadron_map, TargetPdg).E();
+  double MissingMomentum = utils::Missing4Momenta(BeamE, out_mom, hadron_map, TargetPdg).P();
+  double MissingAngle = utils::Missing4Momenta(BeamE, out_mom, hadron_map, TargetPdg).Theta() * TMath::RadToDeg();
+  double MissingTransMomentum = utils::GetPT(utils::Missing4Momenta(BeamE, out_mom, hadron_map, TargetPdg).Vect()).Mag();
 
-    TLorentzVector pi_mom(0, 0, 0, 0);
-    if (topology_has_pip)
+  TLorentzVector pi_mom(0, 0, 0, 0);
+  if (topology_has_pip)
     {
       double max_mom = 0;
       for (unsigned int i = 0; i < hadron_map[conf::kPdgPiP].size(); ++i)
-      {
-        if (hadron_map[conf::kPdgPiP][i].P() > max_mom)
-        {
-          max_mom = hadron_map[conf::kPdgPiP][i].P();
-          pi_mom = hadron_map[conf::kPdgPiP][i];
-        }
-      }
+	{
+	  if (hadron_map[conf::kPdgPiP][i].P() > max_mom)
+	    {
+	      max_mom = hadron_map[conf::kPdgPiP][i].P();
+	      pi_mom = hadron_map[conf::kPdgPiP][i];
+	    }
+	}
     }
-    else if (topology_has_pim)
+  else if (topology_has_pim)
     {
       double max_mom = 0;
       for (unsigned int i = 0; i < hadron_map[conf::kPdgPiM].size(); ++i)
-      {
-        if (hadron_map[conf::kPdgPiM][i].P() > max_mom)
-        {
-          max_mom = hadron_map[conf::kPdgPiM][i].P();
-          pi_mom = hadron_map[conf::kPdgPiM][i];
-        }
-      }
+	{
+	  if (hadron_map[conf::kPdgPiM][i].P() > max_mom)
+	    {
+	      max_mom = hadron_map[conf::kPdgPiM][i].P();
+	      pi_mom = hadron_map[conf::kPdgPiM][i];
+	    }
+	}
     }
 
-    double RecoEvPion = utils::GetRecoEvPionProduction(out_mom, pi_mom);
-    double RecoWPion = utils::GetRecoWPionProduction(out_mom, pi_mom);
-    double ElectronPT = utils::GetPT(out_mom.Vect()).Mag();
-    double PionPT = utils::GetPT(pi_mom.Vect()).Mag();
+  double RecoEvPion = utils::GetRecoEvPionProduction(out_mom, pi_mom);
+  double RecoWPion = utils::GetRecoWPionProduction(out_mom, pi_mom);
+  double ElectronPT = utils::GetPT(out_mom.Vect()).Mag();
+  double PionPT = utils::GetPT(pi_mom.Vect()).Mag();
 
-    bool IsBkg = event.IsBkg();
+  bool IsBkg = event.IsBkg();
 
-    // Store name of files used
-    const char *InputROOTFile = kInputFile.c_str();
-    const char *OutputROOTFile = kOutputFile.c_str();
+  // Store name of files used
+  const char *InputROOTFile = kInputFile.c_str();
+  const char *OutputROOTFile = kOutputFile.c_str();
 
-    if (isFirstCall == true)
+  if (isFirstCall == true)
     {
       kAnalysisTree->Branch("InputROOTFile", &InputROOTFile, "InputROOTFile/C");
       kAnalysisTree->Branch("OutputROOTFile", &OutputROOTFile, "OutputROOTFile/C");
@@ -667,48 +694,48 @@ void AnalysisI::PlotBkgInformation( Event event ) {
       kAnalysisTree->Branch("PionPT", &PionPT, "PionPT/D");
 
       if (topology_has_protons)
-      {
-        kAnalysisTree->Branch("proton_E", &proton_E, "proton_E/D");
-        kAnalysisTree->Branch("proton_mom", &proton_mom, "proton_mom/D");
-        kAnalysisTree->Branch("proton_momx", &proton_momx, "proton_momx/D");
-        kAnalysisTree->Branch("proton_momy", &proton_momy, "proton_momy/D");
-        kAnalysisTree->Branch("proton_momz", &proton_momz, "proton_momz/D");
-        kAnalysisTree->Branch("proton_theta", &proton_theta, "proton_theta/D");
-        kAnalysisTree->Branch("proton_phi", &proton_phi, "proton_phi/D");
-        kAnalysisTree->Branch("AlphaT", &AlphaT, "AlphaT/D");
-        kAnalysisTree->Branch("DeltaPT", &DeltaPT, "DeltaPT/D");
-        kAnalysisTree->Branch("DeltaPhiT", &DeltaPhiT, "DeltaPhiT/D");
-        kAnalysisTree->Branch("AdlerAngleThetaP", &AdlerAngleThetaP, "AdlerAngleThetaP/D");
-        kAnalysisTree->Branch("AdlerAnglePhiP", &AdlerAnglePhiP, "AdlerAnglePhiP/D");
-      }
+	{
+	  kAnalysisTree->Branch("proton_E", &proton_E, "proton_E/D");
+	  kAnalysisTree->Branch("proton_mom", &proton_mom, "proton_mom/D");
+	  kAnalysisTree->Branch("proton_momx", &proton_momx, "proton_momx/D");
+	  kAnalysisTree->Branch("proton_momy", &proton_momy, "proton_momy/D");
+	  kAnalysisTree->Branch("proton_momz", &proton_momz, "proton_momz/D");
+	  kAnalysisTree->Branch("proton_theta", &proton_theta, "proton_theta/D");
+	  kAnalysisTree->Branch("proton_phi", &proton_phi, "proton_phi/D");
+	  kAnalysisTree->Branch("AlphaT", &AlphaT, "AlphaT/D");
+	  kAnalysisTree->Branch("DeltaPT", &DeltaPT, "DeltaPT/D");
+	  kAnalysisTree->Branch("DeltaPhiT", &DeltaPhiT, "DeltaPhiT/D");
+	  kAnalysisTree->Branch("AdlerAngleThetaP", &AdlerAngleThetaP, "AdlerAngleThetaP/D");
+	  kAnalysisTree->Branch("AdlerAnglePhiP", &AdlerAnglePhiP, "AdlerAnglePhiP/D");
+	}
 
       if (topology_has_pip)
-      {
-        kAnalysisTree->Branch("pip_E", &pip_E, "pip_E/D");
-        kAnalysisTree->Branch("pip_mom", &pip_mom, "pip_mom/D");
-        kAnalysisTree->Branch("pip_momx", &pip_momx, "pip_momx/D");
-        kAnalysisTree->Branch("pip_momy", &pip_momy, "pip_momy/D");
-        kAnalysisTree->Branch("pip_momz", &pip_momz, "pip_momz/D");
-        kAnalysisTree->Branch("pip_theta", &pip_theta, "pip_theta/D");
-        kAnalysisTree->Branch("pip_phi", &pip_phi, "pip_phi/D");
-      }
+	{
+	  kAnalysisTree->Branch("pip_E", &pip_E, "pip_E/D");
+	  kAnalysisTree->Branch("pip_mom", &pip_mom, "pip_mom/D");
+	  kAnalysisTree->Branch("pip_momx", &pip_momx, "pip_momx/D");
+	  kAnalysisTree->Branch("pip_momy", &pip_momy, "pip_momy/D");
+	  kAnalysisTree->Branch("pip_momz", &pip_momz, "pip_momz/D");
+	  kAnalysisTree->Branch("pip_theta", &pip_theta, "pip_theta/D");
+	  kAnalysisTree->Branch("pip_phi", &pip_phi, "pip_phi/D");
+	}
 
       if (topology_has_pim)
-      {
-        kAnalysisTree->Branch("pim_E", &pim_E, "pim_E/D");
-        kAnalysisTree->Branch("pim_mom", &pim_mom, "pim_mom/D");
-        kAnalysisTree->Branch("pim_momx", &pim_momx, "pim_momx/D");
-        kAnalysisTree->Branch("pim_momy", &pim_momy, "pim_momy/D");
-        kAnalysisTree->Branch("pim_momz", &pim_momz, "pim_momz/D");
-        kAnalysisTree->Branch("pim_theta", &pim_theta, "pim_theta/D");
-        kAnalysisTree->Branch("pim_phi", &pim_phi, "pim_phi/D");
-      }
+	{
+	  kAnalysisTree->Branch("pim_E", &pim_E, "pim_E/D");
+	  kAnalysisTree->Branch("pim_mom", &pim_mom, "pim_mom/D");
+	  kAnalysisTree->Branch("pim_momx", &pim_momx, "pim_momx/D");
+	  kAnalysisTree->Branch("pim_momy", &pim_momy, "pim_momy/D");
+	  kAnalysisTree->Branch("pim_momz", &pim_momz, "pim_momz/D");
+	  kAnalysisTree->Branch("pim_theta", &pim_theta, "pim_theta/D");
+	  kAnalysisTree->Branch("pim_phi", &pim_phi, "pim_phi/D");
+	}
 
       if (topology_has_pip || topology_has_pim)
-      {
-        kAnalysisTree->Branch("AdlerAngleThetaPi", &AdlerAngleThetaPi, "AdlerAngleThetaPi/D");
-        kAnalysisTree->Branch("AdlerAnglePhiPi", &AdlerAnglePhiPi, "AdlerAnglePhiPi/D");
-      }
+	{
+	  kAnalysisTree->Branch("AdlerAngleThetaPi", &AdlerAngleThetaPi, "AdlerAngleThetaPi/D");
+	  kAnalysisTree->Branch("AdlerAnglePhiPi", &AdlerAnglePhiPi, "AdlerAnglePhiPi/D");
+	}
 
       kAnalysisTree->Branch("HadAlphaT", &HadAlphaT, "HadAlphaT/D");
       kAnalysisTree->Branch("HadDeltaPT", &HadDeltaPT, "HadDeltaPT/D");
@@ -720,13 +747,13 @@ void AnalysisI::PlotBkgInformation( Event event ) {
       isFirstCall = false;
     }
 
-    // Fill
-    kAnalysisTree->Fill();
+  // Fill
+  kAnalysisTree->Fill();
 
-    return true;
-  }
+  return true;
+}
 
-  bool AnalysisI::Finalise(void) {
-    //  if( kElectronFit ) delete kElectronFit ;
-    return true ;
-  }
+bool AnalysisI::Finalise(void) {
+  //  if( kElectronFit ) delete kElectronFit ;
+  return true ;
+}

--- a/src/analysis/AnalysisI.h
+++ b/src/analysis/AnalysisI.h
@@ -31,6 +31,7 @@ namespace e4nu {
     void CookEvent( Event & event ) ;
     void PlotBkgInformation( const Event event ) ;
     void ApplyMomentumCut( Event & event ) ;
+    void SmearParticles( Event & event ) ;
     bool ApplyFiducialCutExtra( Event & event ) ;
     bool ApplyFiducialCut( Event & event, bool apply_fiducial ) ;
     double GetElectronMinTheta( TLorentzVector emom ) ;

--- a/src/analysis/ConfigureI.cxx
+++ b/src/analysis/ConfigureI.cxx
@@ -107,10 +107,25 @@ ConfigureI::ConfigureI( const std::string input_file ) {
       else kApplyPhiOpeningAngle = false ; 
     } else if ( param[i] == "UsePhiThetaBand" ) {
       if( value[i] == "true" ) kUsePhiThetaBand = true ;
-      else kUsePhiThetaBand = false ; 
+      else kUsePhiThetaBand = false ;    
     } else if ( param[i] == "ApplyThetaSlice" ) {
       if ( value[i] == "true" ) kApplyThetaSlice = true ; 
       else kApplyThetaSlice = false ; 
+    } else if ( param[i] == "EThetaSliceRange" ) {
+      std::string etheta ; 
+      std::istringstream range( value[i] ) ;
+      std::vector<double> ethrange ;
+      while( getline( range, etheta, ',' ) ) { 
+	std::cout << " EThetaSlice --> " << etheta << std::endl;
+	ethrange.push_back(atof(etheta.c_str())) ; 
+      }
+      if( ethrange.size() != 2 ) {
+	std::cout << " ERROR: EThetaSliceRange requires two entries separated by comma" << std::endl;
+	kIsConfigured = false;
+      } else {
+	SetEThetaSliceMin( ethrange[0] ) ;
+	SetEThetaSliceMax( ethrange[1] ) ;
+      }
     } else if ( param[i] == "ApplyGoodSectorPhiSlice" ) { 
       if ( value[i] == "true" ) kApplyGoodSectorPhiSlice = true ; 
       else kApplyGoodSectorPhiSlice = false ;

--- a/src/analysis/ConfigureI.h
+++ b/src/analysis/ConfigureI.h
@@ -20,6 +20,7 @@
 #include "conf/FiducialCutI.h"
 #include "utils/Fiducial.h"
 #include "conf/AccpetanceMapsI.h"
+#include "conf/AnalysisConstantsI.h"
 #include <TRandom3.h>
 
 namespace e4nu {
@@ -68,6 +69,10 @@ namespace e4nu {
     bool ApplyPhiOpeningAngle(void) const { return kApplyPhiOpeningAngle ; }
     bool UsePhiThetaBand(void) const { return kUsePhiThetaBand ; }
     bool ApplyThetaSlice(void) const { return kApplyThetaSlice ; }
+    double GetEThetaSliceMin(void) const { return kEThetaSliceMin ; }
+    double GetEThetaSliceMax(void) const { return kEThetaSliceMax ; }
+    void SetEThetaSliceMin( const double ethetamin ) { kEThetaSliceMin = ethetamin ; }
+    void SetEThetaSliceMax( const double ethetamax ) { kEThetaSliceMax = ethetamax ;}
     bool ApplyGoodSectorPhiSlice(void) const { return kApplyGoodSectorPhiSlice ; }
     bool GetOffSet(void) const { return koffset ; }
     bool ApplyQ2Cut(void) const{ return kQ2Cut ; }
@@ -148,6 +153,11 @@ namespace e4nu {
     bool kTrueSignal = false ; // It removes background events before any cuts are applied. This is used for acceptance calculations
     bool kIsRadiated = false ;
 
+    // Theta cuts if requested for inclusive measuremnts
+    double kEThetaSliceMin = conf::kMinEThetaSlice;
+    double kEThetaSliceMax = conf::kMaxEThetaSlice;
+
+    // Run information
     double kEBeam = 1.161 ;
     unsigned int kTargetPdg = 1000060120 ;
     unsigned int kNEvents = 0;

--- a/src/analysis/MCCLAS6AnalysisI.cxx
+++ b/src/analysis/MCCLAS6AnalysisI.cxx
@@ -76,45 +76,15 @@ Event *MCCLAS6AnalysisI::GetValidEvent(const unsigned int event_id)
     return nullptr;
   }
 
-  // Step 3 : smear particles momentum
-  if (ApplyReso())
-  {
-    this->SmearParticles(*event);
-  }
-
   // Step 5: Apply Acceptance Correction (Efficiency correction)
   // This takes into account the efficiency detection of each particle in theta and phi
   // We want to apply it at the end to correctly account for the acceptance in background substracted events
   this->ApplyAcceptanceCorrection(*event);
-  
+
   // Store analysis record after fiducial cut and acceptance correction (2):
-  event->StoreAnalysisRecord(kid_fid);
+  //  event->StoreAnalysisRecord(kid_fid);
 
   return event;
-}
-
-void MCCLAS6AnalysisI::SmearParticles(Event &event)
-{
-  double EBeam = GetConfiguredEBeam();
-  TLorentzVector out_mom = event.GetOutLepton4Mom();
-
-  utils::ApplyResolution(conf::kPdgElectron, out_mom, EBeam);
-  event.SetOutLeptonKinematics(out_mom);
-
-  // Apply for other particles
-  std::map<int, std::vector<TLorentzVector>> part_map = event.GetFinalParticles4Mom();
-  for (std::map<int, std::vector<TLorentzVector>>::iterator it = part_map.begin(); it != part_map.end(); ++it)
-  {
-    std::vector<TLorentzVector> vtemp;
-    for (unsigned int i = 0; i < (it->second).size(); ++i)
-    {
-      TLorentzVector temp = (it->second)[i];
-      utils::ApplyResolution(it->first, temp, EBeam);
-      vtemp.push_back(temp);
-    }
-    part_map[it->first] = vtemp;
-  }
-  event.SetFinalParticlesKinematics(part_map);
 }
 
 unsigned int MCCLAS6AnalysisI::GetNEvents(void) const
@@ -128,6 +98,63 @@ void MCCLAS6AnalysisI::Initialize()
   fData = nullptr;
   
 }
+/*
+void MCCLAS6AnalysisI::SmearParticles( Event & event ) {
+  double EBeam = GetConfiguredEBeam() ; 
+  TLorentzVector out_mom = event.GetOutLepton4Mom() ; 
+
+  utils::ApplyResolution( conf::kPdgElectron, out_mom, EBeam ) ; 
+  event.SetOutLeptonKinematics( out_mom ) ; 
+  
+  // Apply for other particles
+  std::map<int,std::vector<TLorentzVector>> part_map = event.GetFinalParticles4Mom() ;
+  for( std::map<int,std::vector<TLorentzVector>>::iterator it = part_map.begin() ; it != part_map.end() ; ++it ) {
+    std::vector<TLorentzVector> vtemp ; 
+    for( unsigned int i = 0 ; i < (it->second).size() ; ++i ) { 
+      TLorentzVector temp = (it->second)[i] ; 
+      utils::ApplyResolution( it->first, temp, EBeam ) ;
+      vtemp.push_back(temp) ; 
+    }
+    part_map[it->first] = vtemp ; 
+  }
+  event.SetFinalParticlesKinematics( part_map ) ; 
+  
+} 
+
+
+bool MCCLAS6AnalysisI::ApplyFiducialCut( Event & event, bool apply_fiducial ) { 
+  // First, we apply it to the electron
+  // Apply fiducial cut to electron
+  Fiducial * fiducial = GetFiducialCut() ; 
+  if( ! fiducial || IsData() ) return true ; 
+
+  TLorentzVector out_mom = event.GetOutLepton4Mom() ;
+  if (! fiducial -> FiducialCut(conf::kPdgElectron, GetConfiguredEBeam(), out_mom.Vect(), IsData(), apply_fiducial ) ) return false ; 
+  
+  // Apply Fiducial cut for hadrons and photons
+  std::map<int,std::vector<TLorentzVector>> part_map = event.GetFinalParticles4Mom() ;
+  std::map<int,std::vector<TLorentzVector>> part_map_uncorr = event.GetFinalParticlesUnCorr4Mom() ;
+  std::map<int,std::vector<TLorentzVector>> contained_part_map, contained_part_map_uncorr ; 
+  for( auto it = part_map.begin() ; it != part_map.end() ; ++it ) {
+    std::vector<TLorentzVector> visible_part ; 
+    std::vector<TLorentzVector> visible_part_uncorr ; 
+    for( unsigned int i = 0 ; i < part_map[it->first].size() ; ++i ) {
+      if( ! fiducial -> FiducialCut(it->first, GetConfiguredEBeam(), part_map[it->first][i].Vect(), IsData(), apply_fiducial ) ) continue ; 
+      visible_part.push_back( part_map[it->first][i] ) ; 
+      visible_part_uncorr.push_back( part_map_uncorr[it->first][i] ) ; 
+    }
+    if( visible_part.size() == 0 ) continue ; 
+    contained_part_map[it->first] = visible_part ; 
+    contained_part_map_uncorr[it->first] = visible_part_uncorr ; 
+  }
+  
+  // Store changes in event after fiducial cut
+  event.SetFinalParticlesKinematics( contained_part_map ) ; 
+  event.SetFinalParticlesUnCorrKinematics( contained_part_map_uncorr ) ; 
+  
+  return true ; 
+}
+*/
 
 bool MCCLAS6AnalysisI::Finalise(std::map<int, std::vector<e4nu::Event>> &event_holder)
 {

--- a/src/analysis/MCCLAS6AnalysisI.cxx
+++ b/src/analysis/MCCLAS6AnalysisI.cxx
@@ -98,63 +98,6 @@ void MCCLAS6AnalysisI::Initialize()
   fData = nullptr;
   
 }
-/*
-void MCCLAS6AnalysisI::SmearParticles( Event & event ) {
-  double EBeam = GetConfiguredEBeam() ; 
-  TLorentzVector out_mom = event.GetOutLepton4Mom() ; 
-
-  utils::ApplyResolution( conf::kPdgElectron, out_mom, EBeam ) ; 
-  event.SetOutLeptonKinematics( out_mom ) ; 
-  
-  // Apply for other particles
-  std::map<int,std::vector<TLorentzVector>> part_map = event.GetFinalParticles4Mom() ;
-  for( std::map<int,std::vector<TLorentzVector>>::iterator it = part_map.begin() ; it != part_map.end() ; ++it ) {
-    std::vector<TLorentzVector> vtemp ; 
-    for( unsigned int i = 0 ; i < (it->second).size() ; ++i ) { 
-      TLorentzVector temp = (it->second)[i] ; 
-      utils::ApplyResolution( it->first, temp, EBeam ) ;
-      vtemp.push_back(temp) ; 
-    }
-    part_map[it->first] = vtemp ; 
-  }
-  event.SetFinalParticlesKinematics( part_map ) ; 
-  
-} 
-
-
-bool MCCLAS6AnalysisI::ApplyFiducialCut( Event & event, bool apply_fiducial ) { 
-  // First, we apply it to the electron
-  // Apply fiducial cut to electron
-  Fiducial * fiducial = GetFiducialCut() ; 
-  if( ! fiducial || IsData() ) return true ; 
-
-  TLorentzVector out_mom = event.GetOutLepton4Mom() ;
-  if (! fiducial -> FiducialCut(conf::kPdgElectron, GetConfiguredEBeam(), out_mom.Vect(), IsData(), apply_fiducial ) ) return false ; 
-  
-  // Apply Fiducial cut for hadrons and photons
-  std::map<int,std::vector<TLorentzVector>> part_map = event.GetFinalParticles4Mom() ;
-  std::map<int,std::vector<TLorentzVector>> part_map_uncorr = event.GetFinalParticlesUnCorr4Mom() ;
-  std::map<int,std::vector<TLorentzVector>> contained_part_map, contained_part_map_uncorr ; 
-  for( auto it = part_map.begin() ; it != part_map.end() ; ++it ) {
-    std::vector<TLorentzVector> visible_part ; 
-    std::vector<TLorentzVector> visible_part_uncorr ; 
-    for( unsigned int i = 0 ; i < part_map[it->first].size() ; ++i ) {
-      if( ! fiducial -> FiducialCut(it->first, GetConfiguredEBeam(), part_map[it->first][i].Vect(), IsData(), apply_fiducial ) ) continue ; 
-      visible_part.push_back( part_map[it->first][i] ) ; 
-      visible_part_uncorr.push_back( part_map_uncorr[it->first][i] ) ; 
-    }
-    if( visible_part.size() == 0 ) continue ; 
-    contained_part_map[it->first] = visible_part ; 
-    contained_part_map_uncorr[it->first] = visible_part_uncorr ; 
-  }
-  
-  // Store changes in event after fiducial cut
-  event.SetFinalParticlesKinematics( contained_part_map ) ; 
-  event.SetFinalParticlesUnCorrKinematics( contained_part_map_uncorr ) ; 
-  
-  return true ; 
-}
-*/
 
 bool MCCLAS6AnalysisI::Finalise(std::map<int, std::vector<e4nu::Event>> &event_holder)
 {

--- a/src/analysis/MCCLAS6AnalysisI.h
+++ b/src/analysis/MCCLAS6AnalysisI.h
@@ -36,8 +36,6 @@ namespace e4nu {
   private :
 
     Event * GetEvent( const unsigned int event_id ) ;
-    void SmearParticles( Event & event );
-    //bool ApplyFiducialCut( Event & event, bool apply_fiducial );
     MCEventHolder * fData = nullptr ;
     
     void Initialize(void) ;

--- a/src/analysis/MCCLAS6AnalysisI.h
+++ b/src/analysis/MCCLAS6AnalysisI.h
@@ -35,9 +35,9 @@ namespace e4nu {
 
   private :
 
-    void SmearParticles( Event & event ) ;
     Event * GetEvent( const unsigned int event_id ) ;
-
+    void SmearParticles( Event & event );
+    //bool ApplyFiducialCut( Event & event, bool apply_fiducial );
     MCEventHolder * fData = nullptr ;
     
     void Initialize(void) ;

--- a/src/apps/e4nuanalysis.cxx
+++ b/src/apps/e4nuanalysis.cxx
@@ -32,6 +32,7 @@ using namespace e4nu::plotting;
 // --xsec-file) XSecFile (only for MC)                                 //
 // --bkg-mult) Maximum multiplicity used in bkg subtraction method     //
 // --phi-shift) Shift on phy applied to reduce fiducial volume         //
+// --ethetarange ) Set Range on Etheta for inclusive measurement       //
 /////////////////////////////////////////////////////////////////////////
 
 int main( int argc, char* argv[] ) {
@@ -154,6 +155,13 @@ int main( int argc, char* argv[] ) {
     analysis -> SetOutputFile( analysis->GetOutputFile() + "_closuretest"  ) ;
     analysis -> SetDebugBkg(true) ;
     std::cout << " Computing Closure test..."<<std::endl;
+  }
+
+  if( analysis->ApplyPhiOpeningAngle() ) {
+    // For inclusive measurements, we do not want to use all sectors
+    // Later we account for the correct solid angle in the normalization
+    analysis -> SetUseAllSectors( false ) ;
+    analysis -> EnableAllSectors( false ) ;
   }
   
   analysis -> PrintConfiguration() ;

--- a/src/apps/e4nuanalysis.cxx
+++ b/src/apps/e4nuanalysis.cxx
@@ -127,11 +127,10 @@ int main( int argc, char* argv[] ) {
     analysis -> SetApplyAccWeights( false ) ;
     // Correcting for smearing gives unphysical ECal peak. We opt to not correct for this effect
     // MC Generators will have to smear their results to compare against data
-    analysis -> SetApplyReso( false ) ;
-    //analysis -> SetApplyReso( true ) ;
+    analysis -> SetApplyReso( true ) ;
     // !!!!!!!
-    //analysis -> SetUseAllSectors( true ) ;
-    //analysis -> EnableAllSectors( true ) ;
+    analysis -> SetUseAllSectors( true ) ;
+    analysis -> EnableAllSectors( true ) ;
     std::string OutputFile_true = analysis->GetOutputFile() + "_true" ;
     if( analysis -> IsRadiated() ) OutputFile_true += "_radcorr";
     analysis -> SetOutputFile( OutputFile_true ) ;

--- a/src/apps/e4nuanalysis.cxx
+++ b/src/apps/e4nuanalysis.cxx
@@ -127,10 +127,11 @@ int main( int argc, char* argv[] ) {
     analysis -> SetApplyAccWeights( false ) ;
     // Correcting for smearing gives unphysical ECal peak. We opt to not correct for this effect
     // MC Generators will have to smear their results to compare against data
-    analysis -> SetApplyReso( true ) ;
+    analysis -> SetApplyReso( false ) ;
+    //analysis -> SetApplyReso( true ) ;
     // !!!!!!!
-    analysis -> SetUseAllSectors( true ) ;
-    analysis -> EnableAllSectors( true ) ;
+    //analysis -> SetUseAllSectors( true ) ;
+    //analysis -> EnableAllSectors( true ) ;
     std::string OutputFile_true = analysis->GetOutputFile() + "_true" ;
     if( analysis -> IsRadiated() ) OutputFile_true += "_radcorr";
     analysis -> SetOutputFile( OutputFile_true ) ;

--- a/src/conf/AnalysisCutsI.cxx
+++ b/src/conf/AnalysisCutsI.cxx
@@ -14,8 +14,8 @@ double conf::GetMinMomentumCut( const int particle_pdg, const double EBeam ) {
   double min_p = 0 ;
   if( particle_pdg == kPdgElectron ) {
     if( EBeam == 1.161 ) min_p = 0.4 ; 
-    else if ( EBeam == 2.261 ) min_p = 0.55 ;
-    else if ( EBeam == 4.461 ) min_p = 1.3 ; 
+    //else if ( EBeam == 2.261 ) min_p = 0.55 ;
+    //else if ( EBeam == 4.461 ) min_p = 1.3 ; 
   } else if ( particle_pdg == kPdgProton || particle_pdg == kPdgPhoton ) { 
     min_p = 0.3 ; 
   } else if ( particle_pdg == kPdgPiM ) {
@@ -23,6 +23,7 @@ double conf::GetMinMomentumCut( const int particle_pdg, const double EBeam ) {
   } else if ( particle_pdg == kPdgPiP ) { 
     min_p = 0.2 ; 
   }
+
   return min_p ; 
 }
 

--- a/src/conf/AnalysisCutsI.cxx
+++ b/src/conf/AnalysisCutsI.cxx
@@ -14,8 +14,8 @@ double conf::GetMinMomentumCut( const int particle_pdg, const double EBeam ) {
   double min_p = 0 ;
   if( particle_pdg == kPdgElectron ) {
     if( EBeam == 1.161 ) min_p = 0.4 ; 
-    //else if ( EBeam == 2.261 ) min_p = 0.55 ;
-    //else if ( EBeam == 4.461 ) min_p = 1.3 ; 
+    else if ( EBeam == 2.261 ) min_p = 0.55 ;
+    else if ( EBeam == 4.461 ) min_p = 1.3 ; 
   } else if ( particle_pdg == kPdgProton || particle_pdg == kPdgPhoton ) { 
     min_p = 0.3 ; 
   } else if ( particle_pdg == kPdgPiM ) {

--- a/src/plotting/PlottingUtils.cxx
+++ b/src/plotting/PlottingUtils.cxx
@@ -703,7 +703,7 @@ std::vector<double> plotting::GetBinning(std::string observable, double EBeam, s
   else if (observable == "RecoQELEnu")
   {
     if (EBeam == 1.161)
-    binning = plotting::GetUniformBinning(25, 0., 1.3);
+    binning = plotting::GetUniformBinning(20, 0., 0.8);
     else if (EBeam == 2.261)
     binning = plotting::GetUniformBinning(25, 0.3, EBeam + 0.2);
     else if (EBeam == 4.461)
@@ -1717,4 +1717,32 @@ double plotting::ComputeMissingEnergy( const double event_efl, const double even
   else if( slice == 3 && graph_oscillations_3 ) corrected_Emiss = graph_oscillations_3->Interpolate(event_efl,event_ehad) ; // pt > 0.6
 
   return corrected_Emiss ;
+}
+
+std::vector<double> plotting::GetEThetaRange( TTree & tree ) {
+  NEntries = tree.GetEntries();
+
+  plotting::SetAnalysisBranch( &tree ) ;
+  double etheta_min = 9999, etheta_max = 0 ;
+  for (int j = 0; j < NEntries; ++j)
+  {
+    tree.GetEntry(j);
+    if( etheta_min > GetObservable("pfl_theta") ) etheta_min = GetObservable("pfl_theta") ;
+    if( etheta_max < GetObservable("pfl_theta") ) etheta_max = GetObservable("pfl_theta") ;
+  }
+  return {etheta_min,etheta_max};
+}
+
+double plotting::GetEPhiRange( TTree & tree ) {
+  NEntries = tree.GetEntries();
+
+  plotting::SetAnalysisBranch( &tree ) ;
+  double ephi_min = 9999, ephi_max = 0 ;
+  for (int j = 0; j < NEntries; ++j)
+  {
+    tree.GetEntry(j);
+    if( ephi_min > GetObservable("pfl_phi") ) ephi_min = GetObservable("pfl_phi") ;
+    if( ephi_max < GetObservable("pfl_phi") ) ephi_max = GetObservable("pfl_phi") ;
+  }
+  return abs(ephi_max-ephi_min);
 }

--- a/src/plotting/PlottingUtils.h
+++ b/src/plotting/PlottingUtils.h
@@ -61,6 +61,8 @@ namespace e4nu {
     double GetMaximum( std::vector<TH1D*> predictions );
     double GetMaximum( std::vector<TH2D*> predictions );
     double GetMinimum( std::vector<TH1D*> predictions );
+    std::vector<double> GetEThetaRange( TTree & tree ) ;
+    double GetEPhiRange( TTree & tree ) ;
     bool PlotZoomIn(std::string analysis_id="default");
     void StandardFormat( TH1D * prediction, std::string title, int color, int style, std::string observable, bool is_log = false, double y_max = 0, std::string y_axis_label ="" );
     void StandardFormat( TH2D * prediction, std::string title, int color, int style, std::string observable_x, std::string observable_y, double z_max = 0, std::string z_axis_label ="");

--- a/src/plotting/XSecUtils.cxx
+++ b/src/plotting/XSecUtils.cxx
@@ -421,7 +421,7 @@ void plotting::Plot1DXSec(std::vector<std::string> MC_files_name, std::string da
     // Normalize to cross-section
     // INCLUSIVE NORMALIZATION
     DataNormalization /= solid_angle;
-    // DataNormalization*=1.7;
+
     NormalizeHist(hist_data, DataNormalization);
     NormalizeHist(hist_data_0, DataNormalization);
     NormalizeHist(hist_data_1, DataNormalization);

--- a/src/utils/Fiducial.cxx
+++ b/src/utils/Fiducial.cxx
@@ -647,6 +647,7 @@ Bool_t Fiducial::FiducialCutExtra( const int pdg, const double beam_en, TVector3
   else if ( pdg == conf::kPdgPiP ) extra *= PiplFiducialCutExtra( beam_en, momentum ) ;
   else if ( pdg == conf::kPdgPiM ) extra *= PimiFiducialCutExtra(beam_en, momentum) ;
   else if ( pdg == conf::kPdgPhoton ) extra *= Phot_fidExtra(momentum) ;    
+  
   if ( extra == false ) return false ; 
 			     
   return true ;


### PR DESCRIPTION
This pull request merges changes necessary to:
- Reproduce 1p0pi results. Differences exist due to fixed acceptance, not correcting for mom smearing.
- Automatically reproduce the inclusive spectra without changes in the code. The true distribution is computed without enabling all sectors. Also, the theta cut is now configurable and the plotting scripts normalize by solid angle. 

C(e,e'1p0pi) @ 1 GeV: 

![image](https://github.com/user-attachments/assets/d63de521-f8e8-4ff7-b665-2a9ac5684c6c)
![image](https://github.com/user-attachments/assets/6ca50aa6-6f66-4bef-b17c-58163a8909cf)

C(e,e') @ 1 GeV, 36<theta_e'<39deg, deltaPhi = 12 deg, only using first sector 

![image](https://github.com/user-attachments/assets/fe100f4f-437a-4ff5-b680-6c880fca7cd1)

The disagreement with the nature paper result or Arie's results are not understood yet. However, the normalization has been validated using an external script to compute the MC prediction. It matches the MC predicted by my code (used to compare with Arie's predictions) and also the e4nu analysis code. This shows the issue is not in the normalization itself. 


